### PR TITLE
consider array-style json data

### DIFF
--- a/src/jrender.js
+++ b/src/jrender.js
@@ -54,7 +54,7 @@ var Render = {
                 html = decodeURIComponent($(child).attr('row-html'));
             }
             $(child).html('');
-            $(values[key]).each(function(index,value) {
+            $((key=='.')?values:values[key]).each(function(index,value) {
                 if(typeof value!='object') {
                     var tmp = {
                         'self':value


### PR DESCRIPTION
For array-style json data (e.g. `[{"key":"value"...}{"key":"value"...}]`), may use `render-loop='.'` for the parent node, and things like `render-html='..id'` *(double-dot prefix)* for child nodes in html code.